### PR TITLE
Configure webpack to use babel-loader with @babel/preset-env

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,22 @@
 const path = require("path");
 
 module.exports = {
-  mode: "development",
+  mode: "production",
   entry: "./src/index.js",
   output: {
     path: path.join(__dirname, "dist"),
     filename: "app.bundle.js",
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        loader: "babel-loader",
+        exclude: /node_modules/,
+        options: {
+          presets: ["@babel/preset-env"],
+        },
+      },
+    ],
   },
 };


### PR DESCRIPTION
Closes #14 

The goal of this PR is to configure Webpack to convert JavaScript into an old-fashioned version. For this, I updated the webpack.config.js file to use the module instruction, with babel-loader config.