### PR TITLE
#26: enable source-map option to improve debugger

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -6,4 +6,5 @@ module.exports = merge(baseConfig, {
   devServer: {
     port: 3001,
   },
+  devtool: "source-map",
 });


### PR DESCRIPTION
Closes #26 

This PR is aimed to improve debugger in our code.

To use this, you can simple use **debugger** word in your code.