### PR TITLE
#31 - externalize React and ReactDOM for production bundle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,5 +7,16 @@
   </head>
   <body>
     <div id="app"></div>
+
+    <% if(process.env.NODE_ENV === 'production') { %>
+    <script
+      crossorigin
+      src="https://unpkg.com/react@16/umd/react.production.min.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"
+    ></script>
+    <% } %>
   </body>
 </html>

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -14,4 +14,8 @@ module.exports = merge(baseConfig, {
     ],
   },
   plugins: [new MiniCssExtractPlugin()],
+  externals: {
+    react: "React",
+    "react-dom": "ReactDOM",
+  },
 });


### PR DESCRIPTION
Closes #31 

When generating a production bundle I want that React and ReactDOM libraries become external.